### PR TITLE
Use JSON output format instead of XML output format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'scss-lint'
+gem 'scss_lint'

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "chalk": "^0.4.0",
     "event-stream": "^3.1.5",
     "gulp-util": "^2.2.14",
-    "map-stream": "^0.1.0",
-    "xml2js": "^0.4.2"
+    "map-stream": "^0.1.0"
   },
   "devDependencies": {
     "mocha": "^1.18.2",

--- a/test/fixtures/pass with spaces.scss
+++ b/test/fixtures/pass with spaces.scss
@@ -1,3 +1,3 @@
 body {
-  color: #333;
+  font-size: 1em;
 }


### PR DESCRIPTION
XML output format has been removed from scss-lint in 0.39.0

It also updates the name of the gem to scss_lint and fixes a problem with the "should handle scss file paths with spaces" test.
